### PR TITLE
Fix: Handle BOM in xml before parsing with XslTransformer

### DIFF
--- a/src/main/java/io/github/easybill/xrviz/XmlHelper.java
+++ b/src/main/java/io/github/easybill/xrviz/XmlHelper.java
@@ -1,0 +1,14 @@
+package io.github.easybill.xrviz;
+
+public class XmlHelper {
+    public static String removeBOM(String str) {
+        // Check if XML contains BOM, if so, we will remove if due to the XslTransformer having issues with anything
+        // before the XML prolog.
+        if (str.startsWith("\uFEFF")) {
+            return str.substring(1);
+        }
+
+        return str;
+    }
+
+}

--- a/src/main/java/io/github/easybill/xrviz/handler/HtmlHandler.java
+++ b/src/main/java/io/github/easybill/xrviz/handler/HtmlHandler.java
@@ -2,6 +2,7 @@ package io.github.easybill.xrviz.handler;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
+import io.github.easybill.xrviz.XmlHelper;
 import io.github.easybill.xrviz.XslTransformer;
 
 import javax.xml.transform.TransformerException;
@@ -14,11 +15,14 @@ public class HtmlHandler extends XmlRequestExtractor implements HttpHandler {
         logger.info("HTML conversion requested");
         try {
             var xml = validate(exchange);
+
             if (xml.isEmpty()) {
                 return;
             }
 
-            byte[] response = XslTransformer.transformToHtml(xml.get(), getLanguage(exchange)).getBytes(StandardCharsets.UTF_8);
+            var xmlContent = XmlHelper.removeBOM(xml.get());
+
+            byte[] response = XslTransformer.transformToHtml(xmlContent, getLanguage(exchange)).getBytes(StandardCharsets.UTF_8);
 
             exchange.getResponseHeaders().set("Content-Type", "text/html");
             exchange.sendResponseHeaders(200, response.length);

--- a/src/main/java/io/github/easybill/xrviz/handler/PdfHandler.java
+++ b/src/main/java/io/github/easybill/xrviz/handler/PdfHandler.java
@@ -2,8 +2,10 @@ package io.github.easybill.xrviz.handler;
 
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
+import io.github.easybill.xrviz.XmlHelper;
 import io.github.easybill.xrviz.XslTransformer;
 import org.apache.fop.apps.FOPException;
+import org.apache.fop.render.txt.Helper;
 
 import javax.xml.transform.TransformerException;
 import java.io.IOException;
@@ -14,11 +16,14 @@ public class PdfHandler extends XmlRequestExtractor implements HttpHandler {
         logger.info("PDF conversion requested");
         try {
             var xml = validate(exchange);
+
             if (xml.isEmpty()) {
                 return;
             }
 
-            byte[] response = XslTransformer.transformToPdf(xml.get(), getLanguage(exchange));
+            var xmlContent = XmlHelper.removeBOM(xml.get());
+
+            byte[] response = XslTransformer.transformToPdf(xmlContent, getLanguage(exchange));
 
             exchange.getResponseHeaders().set("Content-Type", "application/pdf");
             exchange.sendResponseHeaders(200, response.length);

--- a/src/test/http/api-test.http
+++ b/src/test/http/api-test.http
@@ -58,3 +58,11 @@ Content-Type: application/xml
 Accept-Language: de
 
 < ./ubl-creditnote.xml
+
+
+### Generate a PDF file from a XML with UTF-8 BOM
+POST {{baseUrl}}/convert.pdf
+Content-Type: application/xml
+Accept-Language: de
+
+< ./output_with_bom.xml

--- a/src/test/http/api-test.http
+++ b/src/test/http/api-test.http
@@ -66,3 +66,10 @@ Content-Type: application/xml
 Accept-Language: de
 
 < ./output_with_bom.xml
+
+### Generate a HTML file from a XML with UTF-8 BOM
+POST {{baseUrl}}/convert.html
+Content-Type: application/xml
+Accept-Language: de
+
+< ./output_with_bom.xml

--- a/src/test/http/output_with_bom.xml
+++ b/src/test/http/output_with_bom.xml
@@ -1,0 +1,158 @@
+﻿<?xml version='1.0' encoding='UTF-8' ?>
+<rsm:CrossIndustryInvoice xmlns:rsm="urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100" xmlns:qdt="urn:un:unece:uncefact:data:standard:QualifiedDataType:100" xmlns:ram="urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:udt="urn:un:unece:uncefact:data:standard:UnqualifiedDataType:100">
+    <rsm:ExchangedDocumentContext>
+        <ram:GuidelineSpecifiedDocumentContextParameter>
+            <ram:ID>urn:cen.eu:en16931:2017</ram:ID>
+        </ram:GuidelineSpecifiedDocumentContextParameter>
+    </rsm:ExchangedDocumentContext>
+    <rsm:ExchangedDocument>
+        <ram:ID>471102</ram:ID>
+        <ram:TypeCode>380</ram:TypeCode>
+        <ram:IssueDateTime>
+            <udt:DateTimeString format="102">20180305</udt:DateTimeString>
+        </ram:IssueDateTime>
+        <ram:IncludedNote>
+            <ram:Content>Rechnung gemäß Bestellung vom 01.03.2018.</ram:Content>
+        </ram:IncludedNote>
+        <ram:IncludedNote>
+            <ram:Content>Lieferant GmbH
+                Lieferantenstraße 20
+                80333 München
+                Deutschland
+                Geschäftsführer: Hans Muster
+                Handelsregisternummer: H A 123
+            </ram:Content>
+            <ram:SubjectCode>REG</ram:SubjectCode>
+        </ram:IncludedNote>
+    </rsm:ExchangedDocument>
+    <rsm:SupplyChainTradeTransaction>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>1</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedTradeProduct>
+                <ram:GlobalID schemeID="0160">4012345001235</ram:GlobalID>
+                <ram:SellerAssignedID>TB100A4</ram:SellerAssignedID>
+                <ram:Name>Trennblätter A4</ram:Name>
+            </ram:SpecifiedTradeProduct>
+            <ram:SpecifiedLineTradeAgreement>
+                <ram:GrossPriceProductTradePrice>
+                    <ram:ChargeAmount>9.9000</ram:ChargeAmount>
+                </ram:GrossPriceProductTradePrice>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount>9.9000</ram:ChargeAmount>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+            <ram:SpecifiedLineTradeDelivery>
+                <ram:BilledQuantity unitCode="H87">20.0000</ram:BilledQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+            <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount>198.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:IncludedSupplyChainTradeLineItem>
+            <ram:AssociatedDocumentLineDocument>
+                <ram:LineID>2</ram:LineID>
+            </ram:AssociatedDocumentLineDocument>
+            <ram:SpecifiedTradeProduct>
+                <ram:GlobalID schemeID="0160">4000050986428</ram:GlobalID>
+                <ram:SellerAssignedID>ARNR2</ram:SellerAssignedID>
+                <ram:Name>Joghurt Banane</ram:Name>
+            </ram:SpecifiedTradeProduct>
+            <ram:SpecifiedLineTradeAgreement>
+                <ram:GrossPriceProductTradePrice>
+                    <ram:ChargeAmount>5.5000</ram:ChargeAmount>
+                </ram:GrossPriceProductTradePrice>
+                <ram:NetPriceProductTradePrice>
+                    <ram:ChargeAmount>5.5000</ram:ChargeAmount>
+                </ram:NetPriceProductTradePrice>
+            </ram:SpecifiedLineTradeAgreement>
+            <ram:SpecifiedLineTradeDelivery>
+                <ram:BilledQuantity unitCode="H87">50.0000</ram:BilledQuantity>
+            </ram:SpecifiedLineTradeDelivery>
+            <ram:SpecifiedLineTradeSettlement>
+                <ram:ApplicableTradeTax>
+                    <ram:TypeCode>VAT</ram:TypeCode>
+                    <ram:CategoryCode>S</ram:CategoryCode>
+                    <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+                </ram:ApplicableTradeTax>
+                <ram:SpecifiedTradeSettlementLineMonetarySummation>
+                    <ram:LineTotalAmount>275.00</ram:LineTotalAmount>
+                </ram:SpecifiedTradeSettlementLineMonetarySummation>
+            </ram:SpecifiedLineTradeSettlement>
+        </ram:IncludedSupplyChainTradeLineItem>
+        <ram:ApplicableHeaderTradeAgreement>
+            <ram:SellerTradeParty>
+                <ram:ID>549910</ram:ID>
+                <ram:GlobalID schemeID="0088">4000001123452</ram:GlobalID>
+                <ram:Name>Lieferant GmbH</ram:Name>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>80333</ram:PostcodeCode>
+                    <ram:LineOne>Lieferantenstraße 20</ram:LineOne>
+                    <ram:CityName>München</ram:CityName>
+                    <ram:CountryID>DE</ram:CountryID>
+                </ram:PostalTradeAddress>
+                <ram:SpecifiedTaxRegistration>
+                    <ram:ID schemeID="FC">201/113/40209</ram:ID>
+                </ram:SpecifiedTaxRegistration>
+                <ram:SpecifiedTaxRegistration>
+                    <ram:ID schemeID="VA">DE123456789</ram:ID>
+                </ram:SpecifiedTaxRegistration>
+            </ram:SellerTradeParty>
+            <ram:BuyerTradeParty>
+                <ram:ID>GE2020211</ram:ID>
+                <ram:Name>Kunden AG Mitte</ram:Name>
+                <ram:PostalTradeAddress>
+                    <ram:PostcodeCode>69876</ram:PostcodeCode>
+                    <ram:LineOne>Kundenstraße 15</ram:LineOne>
+                    <ram:CityName>Frankfurt</ram:CityName>
+                    <ram:CountryID>DE</ram:CountryID>
+                </ram:PostalTradeAddress>
+            </ram:BuyerTradeParty>
+        </ram:ApplicableHeaderTradeAgreement>
+        <ram:ApplicableHeaderTradeDelivery>
+            <ram:ActualDeliverySupplyChainEvent>
+                <ram:OccurrenceDateTime>
+                    <udt:DateTimeString format="102">20180305</udt:DateTimeString>
+                </ram:OccurrenceDateTime>
+            </ram:ActualDeliverySupplyChainEvent>
+        </ram:ApplicableHeaderTradeDelivery>
+        <ram:ApplicableHeaderTradeSettlement>
+            <ram:InvoiceCurrencyCode>EUR</ram:InvoiceCurrencyCode>
+            <ram:ApplicableTradeTax>
+                <ram:CalculatedAmount>19.25</ram:CalculatedAmount>
+                <ram:TypeCode>VAT</ram:TypeCode>
+                <ram:BasisAmount>275.00</ram:BasisAmount>
+                <ram:CategoryCode>S</ram:CategoryCode>
+                <ram:RateApplicablePercent>7.00</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:ApplicableTradeTax>
+                <ram:CalculatedAmount>37.62</ram:CalculatedAmount>
+                <ram:TypeCode>VAT</ram:TypeCode>
+                <ram:BasisAmount>198.00</ram:BasisAmount>
+                <ram:CategoryCode>S</ram:CategoryCode>
+                <ram:RateApplicablePercent>19.00</ram:RateApplicablePercent>
+            </ram:ApplicableTradeTax>
+            <ram:SpecifiedTradePaymentTerms>
+                <ram:Description>Zahlbar innerhalb 30 Tagen netto bis 04.04.2018, 3% Skonto innerhalb 10 Tagen bis 15.03.2018</ram:Description>
+            </ram:SpecifiedTradePaymentTerms>
+            <ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+                <ram:LineTotalAmount>473.00</ram:LineTotalAmount>
+                <ram:ChargeTotalAmount>0.00</ram:ChargeTotalAmount>
+                <ram:AllowanceTotalAmount>0.00</ram:AllowanceTotalAmount>
+                <ram:TaxBasisTotalAmount>473.00</ram:TaxBasisTotalAmount>
+                <ram:TaxTotalAmount currencyID="EUR">56.87</ram:TaxTotalAmount>
+                <ram:GrandTotalAmount>529.87</ram:GrandTotalAmount>
+                <ram:TotalPrepaidAmount>0.00</ram:TotalPrepaidAmount>
+                <ram:DuePayableAmount>529.87</ram:DuePayableAmount>
+            </ram:SpecifiedTradeSettlementHeaderMonetarySummation>
+        </ram:ApplicableHeaderTradeSettlement>
+    </rsm:SupplyChainTradeTransaction>
+</rsm:CrossIndustryInvoice>


### PR DESCRIPTION
```
[2024-09-16 12:00:58] [INFO   ] PDF conversion requested
Error on line 1 column 1
  SXXP0003   Error reported by XML parser: Content is not allowed in prolog.
Error
  SXXP0003  SXXP0003   Error reported by XML parser: Content is not allowed in prolog.
[2024-09-16 12:00:58] [SEVERE ] Error while transforming XML to PDF: SXXP0003   Error reported by XML parser: Content is not allowed in prolog.
```