### PR TITLE
fix: one xml parse error causes all subsequent parses to fail as well

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-currentVersion=0.1.11
+currentVersion=0.1.12
 mainClassName=io.github.easybill.xrviz.App

--- a/version-badge.svg
+++ b/version-badge.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="90" height="20" role="img" aria-label="Version: 0.1.11">
+<svg xmlns="http://www.w3.org/2000/svg" width="90" height="20" role="img" aria-label="Version: 0.1.12">
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -15,7 +15,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
     <text aria-hidden="true" x="265" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="410">Version</text>
     <text x="265" y="140" transform="scale(.1)" fill="#fff" textLength="410">Version</text>
-    <text aria-hidden="true" x="695" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="290">0.1.11</text>
-    <text x="695" y="140" transform="scale(.1)" fill="#fff" textLength="290">0.1.11</text>
+    <text aria-hidden="true" x="695" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="290">0.1.12</text>
+    <text x="695" y="140" transform="scale(.1)" fill="#fff" textLength="290">0.1.12</text>
   </g>
 </svg>


### PR DESCRIPTION
The error handler of XMLReader maintains an application wide error count. When one request fails due to a parsing error all subsequent requests fail as well because the error count remains >0.

In this example 2 badly formed XMLs were sent to the endpoint, followed by a valid XML, which fails due to the `fatalErrorCount` being >0.
![image](https://github.com/user-attachments/assets/8f564f82-3880-47da-ac1c-2f163009cbe9)
![image](https://github.com/user-attachments/assets/8a044238-81d9-4556-a8ce-8a21dead4565)
